### PR TITLE
Changed beginning from <? to <?php standard

### DIFF
--- a/phpwee.php
+++ b/phpwee.php
@@ -1,5 +1,7 @@
-<?
+<?php
+
 namespace PHPWee;
+
 require_once("src/CssMin/CssMin.php");
 require_once("src/HtmlMin/HtmlMin.php");
 require_once("src/JsMin/JsMin.php");


### PR DESCRIPTION
Took me a while to find why the class wasn't being included, don't have short open tags enabled.
