### PR TITLE
Removing short <? tag, adding <?php full tag

### DIFF
--- a/phpwee.php
+++ b/phpwee.php
@@ -1,4 +1,4 @@
-<?
+<?php
 namespace PHPWee;
 require_once("src/CssMin/CssMin.php");
 require_once("src/HtmlMin/HtmlMin.php");


### PR DESCRIPTION
There is a problem on systems with disabled php (short_open_tag = 0, by default).