### PR TITLE
Trimming nodes' values discards valid whitespaces

### DIFF
--- a/src/HtmlMin/HtmlMin.php
+++ b/src/HtmlMin/HtmlMin.php
@@ -85,7 +85,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 						continue;
 					}
 					if($c->nodeType==3){
-						$c->nodeValue = trim($c->nodeValue);
+						//$c->nodeValue = trim($c->nodeValue);
 					}
 				}
 			}


### PR DESCRIPTION
For instance: `Foo <strong>Bar</strong>` would  become `Foo<strong>Bar</strong>`, which is incorrect.